### PR TITLE
Added support for frequency input data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,9 @@ Title: Plotting Lorenz Curve with the Blessing of 'ggplot2'
 Version: 0.0.1.9000
 Authors@R: c(
         person("JJ", "Chen", email = "jiajia.chern@gmail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0001-8482-8398"))
+           comment = c(ORCID = "0000-0001-8482-8398")),
+        person("Hernando", "Cortina", email = "hch@alum.mit.edu", role = c("aut"),
+           comment = c(ORCID = "0000-0001-6790-4870"))   
            )
 Description: Provides statistical transformations for plotting empirical 
     ordinary Lorenz curve (Lorenz 1905) <doi:10.2307/2276207> and 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 
 # gglorenz 0.0.1
 
-* Inital release with a data set `billionaires` and two functions `stat_lorenz()` and `stat_lorenz_generalized()`.
+* Initial release with a data set `billionaires` and two functions `stat_lorenz()` and `stat_lorenz_generalized()`.
 * Added a `NEWS.md` file to track changes to the package.
+* Added support for frequency input in dataset (PR #1)

--- a/R/stat_lorenz.R
+++ b/R/stat_lorenz.R
@@ -24,6 +24,11 @@
 #'     coord_fixed() +
 #'     geom_abline(linetype = "dashed") +
 #'     theme_minimal()
+#'
+#'  Optional frequency aesthetic n
+#'
+#' ggplot(population, aes(x=TNW, n=number)) +
+#'     stat_lorenz()
 stat_lorenz <- function(mapping = NULL, data = NULL,
                         geom = "path", position = "identity",
                         ...,
@@ -62,7 +67,12 @@ StatLorenz <- ggproto("StatLorenz", Stat,
                                    non-negative elements.", call. = FALSE)
                           }
 
-                          Lc <- ineq::Lc(data$x)
+                          if (any(names(data) == 'n') & any(data$n < 0)) {
+                              stop("stat_lorenz() requires a vector containing
+                                   non-negative frequencies", call. = FALSE)
+                          }
+
+                          if (any(names(data) == 'n')) Lc <- ineq::Lc(data$x, data$n) else Lc <- ineq::Lc(data$x)
 
                           if (desc) {
                               data.frame(x = 1 - Lc$p,


### PR DESCRIPTION
ineq::Lc() supports both the value data (x) and an optional second input for frequencies (n).  This is useful in the case many members of the population have the same x values.  This commit adds support for optional n.  Default behavior of stat_lorenz() is unchanged.
